### PR TITLE
Declaring the delimiters variable.

### DIFF
--- a/lib/balloon.js
+++ b/lib/balloon.js
@@ -1,7 +1,7 @@
 var os = require("os");
 
 exports.say = function (text, wrap) {
-	delimiters = {
+	var delimiters = {
 		first : ["/", "\\"],
 		middle : ["|", "|"],
 		last : ["\\", "/"],


### PR DESCRIPTION
This is breaking the [next.js](https://github.com/zeit/next.js) README example